### PR TITLE
New music support

### DIFF
--- a/anim.py
+++ b/anim.py
@@ -796,13 +796,16 @@ def comments_to_scene(comments: List, characters: Dict, name_music = "PWR", **kw
             if name_music == 'PWR':
                 if last_audio != "08 - Pressing Pursuit _ Cornered":
                     last_audio = "08 - Pressing Pursuit _ Cornered"
+                    change_audio = True
             elif name_music == 'JFA':
                 if last_audio != "Phoenix Wright Ace Attorney_ Justice for All OST - Pressing Pursuit _ Cross-Examine":
                     last_audio = "Phoenix Wright Ace Attorney_ Justice for All OST - Pressing Pursuit _ Cross-Examine"
+                    change_audio = True
             else:
                 if last_audio != "Phoenix Wright_ Trials and Tribulations OST - Pressing Pursuit _ Caught":
                     last_audio = "Phoenix Wright_ Trials and Tribulations OST - Pressing Pursuit _ Caught"
-            change_audio = True
+                    change_audio = True
+            
         for obj in character_block:
             scene_objs.append(
                 {

--- a/anim.py
+++ b/anim.py
@@ -730,7 +730,7 @@ def get_characters(most_common: List):
     return characters
 
 
-def comments_to_scene(comments: List, characters: Dict, **kwargs, name_music):
+def comments_to_scene(comments: List, characters: Dict, name_music = "PWR", **kwargs):
     scene = []
     inv_characters = {v: k for k, v in characters.items()}
     for comment in comments:

--- a/anim.py
+++ b/anim.py
@@ -730,7 +730,7 @@ def get_characters(most_common: List):
     return characters
 
 
-def comments_to_scene(comments: List, characters: Dict, **kwargs):
+def comments_to_scene(comments: List, characters: Dict, **kwargs, name_music):
     scene = []
     inv_characters = {v: k for k, v in characters.items()}
     for comment in comments:
@@ -777,7 +777,12 @@ def comments_to_scene(comments: List, characters: Dict, **kwargs):
             )
         scene.append(character_block)
     formatted_scenes = []
-    last_audio = "03 - Turnabout Courtroom - Trial"
+    if name_music == 'PWR':
+        last_audio = "03 - Turnabout Courtroom - Trial"
+    elif name_music == 'JFA':
+        last_audio = "Phoenix Wright Ace Attorney_ Justice for All OST - Trial"
+    else:
+        last_audio = "Phoenix Wright_ Trials and Tribulations OST - Trial"
     change_audio = True
     for character_block in scene:
         scene_objs = []
@@ -788,9 +793,16 @@ def comments_to_scene(comments: List, characters: Dict, **kwargs):
                     "action": Action.OBJECTION,
                 }
             )
-            if last_audio != "08 - Pressing Pursuit _ Cornered":
-                last_audio = "08 - Pressing Pursuit _ Cornered"
-                change_audio = True
+            if name_music == 'PWR':
+                if last_audio != "08 - Pressing Pursuit _ Cornered":
+                    last_audio = "08 - Pressing Pursuit _ Cornered"
+            elif name_music == 'JFA':
+                if last_audio != "Phoenix Wright Ace Attorney_ Justice for All OST - Pressing Pursuit _ Cross-Examine":
+                    last_audio = "Phoenix Wright Ace Attorney_ Justice for All OST - Pressing Pursuit _ Cross-Examine"
+            else:
+                if last_audio != "Phoenix Wright_ Trials and Tribulations OST - Pressing Pursuit _ Caught":
+                    last_audio = "Phoenix Wright_ Trials and Tribulations OST - Pressing Pursuit _ Caught"
+            change_audio = True
         for obj in character_block:
             scene_objs.append(
                 {


### PR DESCRIPTION
A new argument has been given to the function "comments_to_scene", name_music. Depending of the value of this string, the music should change when rendering the video. The possible values of name_music are:

PWR: Just like the default bot, using music from the first game
JFA: Music from Justice for All
TAT: Music from Trials and Tribulations

The new music tracks are in this folder: https://drive.google.com/drive/folders/1CSMvRfn8awGaZV_6Lra0hseYo4LsbP85?usp=sharing 
The music files' names are the same ones as in the code.
I'm sure this isn't perfect, so please tell me any mistakes I may have made :)